### PR TITLE
Update pyproject.toml to reference bunnet instead of beanie

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,10 @@ queue = ["beanie-batteries-queue>=0.2"]
 
 [project.urls]
 homepage = "https://beanie-odm.dev"
-repository = "https://github.com/roman-right/beanie"
+repository = "https://github.com/roman-right/bunnet"
 
 [project.scripts]
-beanie = "beanie.executors.migrate:migrations"
+bunnet = "bunnet.executors.migrate:migrations"
 
 # TOOLS
 


### PR DESCRIPTION
bunnet did not work from the CLI (it was not registered to be called externally), as is documented in the [migrations help](https://beanieodm.github.io/bunnet/tutorial/migrations/), so this was modified so bunnet can actually be called. Updating the help would be okay too, but it seems like it's best to have this work in bunnet, instead of relying on beanie.

Note that there are other references to bunnet in this file that could likely be fixed, but I dont want to change things I don't have a good understanding of.